### PR TITLE
fix(mkt): license link

### DIFF
--- a/apps/mkt/components/ui/footer.tsx
+++ b/apps/mkt/components/ui/footer.tsx
@@ -90,7 +90,7 @@ export default function Footer() {
               <li>
                 <a
                   className="text-zinc-500 hover:text-dark-100 transition"
-                  href="https://github.com/sweetr-dev/sweetr.dev/blob/main/LICENSE.md"
+                  href="https://github.com/sweetr-dev/sweetr.dev/blob/main/LICENSE"
                   target="_blank"
                   rel="nofollow"
                 >


### PR DESCRIPTION
## Summary

- Fix the license link in the marketing website footer