### PR TITLE
feat: valkey

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,16 +32,12 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      dragonfly:
-        image: docker.dragonflydb.io/dragonflydb/dragonfly
-        env:
-          DFLY_cluster_mode: emulated
-          DFLY_lock_on_hashtags: "true"
-
+      valkey:
+        image: valkey/valkey:8-alpine
         ports:
           - 6379:6379
         options: >-
-          --health-cmd "redis-cli ping"
+          --health-cmd "valkey-cli ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -30,13 +30,12 @@ jobs:
           --health-timeout 5s
           --health-retries 10
 
-      dragonfly:
-        image: docker.dragonflydb.io/dragonflydb/dragonfly
+      valkey:
+        image: valkey/valkey:8-alpine
         ports:
           - 6379:6379
         options: >-
-          --ulimit memlock=-1
-          --health-cmd "redis-cli ping | grep -q PONG"
+          --health-cmd "valkey-cli ping | grep -q PONG"
           --health-interval 2s
           --health-timeout 5s
           --health-retries 10

--- a/apps/docs/get-started/self-host.mdx
+++ b/apps/docs/get-started/self-host.mdx
@@ -205,7 +205,7 @@ If you prefer to set things up manually, follow the steps below.
         depends_on:
           postgres:
             condition: service_healthy
-          dragonfly:
+          valkey:
             condition: service_healthy
 
       web:
@@ -238,26 +238,23 @@ If you prefer to set things up manually, follow the steps below.
           timeout: 5s
           retries: 5
 
-      dragonfly:
-        image: docker.dragonflydb.io/dragonflydb/dragonfly
-        container_name: sweetr-dragonfly
-        command: ["--cluster_mode=emulated", "--lock_on_hashtags", "--proactor_threads=2"]
-        ulimits:
-          memlock: -1
+      valkey:
+        image: valkey/valkey:8-alpine
+        container_name: sweetr-valkey
         volumes:
-          - sweetr-dragonfly:/data
+          - sweetr-valkey:/data
         restart: unless-stopped
         networks:
           - sweetr
         healthcheck:
-          test: ["CMD-SHELL", "redis-cli ping"]
+          test: ["CMD-SHELL", "valkey-cli ping"]
           interval: 10s
           timeout: 5s
           retries: 5
 
     volumes:
       sweetr-db:
-      sweetr-dragonfly:
+      sweetr-valkey:
       sweetr-caddy-data:
       sweetr-caddy-config:
 
@@ -282,7 +279,7 @@ If you prefer to set things up manually, follow the steps below.
     PORT=8000
     FRONTEND_URL=https://your-domain.com
     JWT_SECRET=<generate-a-secure-random-string>
-    REDIS_CONNECTION_STRING=redis://dragonfly:6379
+    REDIS_CONNECTION_STRING=redis://valkey:6379
 
     # GitHub App
     GITHUB_APP_ID=<your-app-id>
@@ -326,7 +323,7 @@ If you prefer to set things up manually, follow the steps below.
 | Variable                                          | Required | Default            | Description                                |
 | ------------------------------------------------- | -------- | ------------------ | ------------------------------------------ |
 | `DATABASE_URL`                                    | Yes      | —                  | PostgreSQL connection string               |
-| `REDIS_CONNECTION_STRING`                         | Yes      | —                  | Redis/Dragonfly connection string          |
+| `REDIS_CONNECTION_STRING`                         | Yes      | —                  | Redis/Valkey connection string             |
 | `JWT_SECRET`                                      | Yes      | —                  | Secret for signing JWT tokens              |
 | `FRONTEND_URL`                                    | Yes      | —                  | URL of the web application                 |
 | `PORT`                                            | No       | `3000`             | API server port                            |
@@ -441,7 +438,7 @@ Common causes:
 
 - **Database connection failed**: Ensure Postgres is healthy with `docker compose ps`. The API waits for migrations to run on startup.
 - **Missing environment variables**: The API will log which required variables are missing.
-- **Redis connection failed**: Ensure Dragonfly is healthy. Check that `REDIS_CONNECTION_STRING` uses the Docker service name (e.g., `redis://dragonfly:6379`).
+- **Redis connection failed**: Ensure Valkey is healthy. Check that `REDIS_CONNECTION_STRING` uses the Docker service name (e.g., `redis://valkey:6379`).
 
 ### Web app shows blank page
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -297,7 +297,7 @@ DATABASE_URL=postgres://postgres:${DB_PASSWORD}@postgres:5432/sweetr
 PORT=8000
 FRONTEND_URL=${URL_SCHEME}://${DOMAIN}
 JWT_SECRET=${JWT_SECRET}
-REDIS_CONNECTION_STRING=redis://dragonfly:6379
+REDIS_CONNECTION_STRING=redis://valkey:6379
 
 # GitHub App
 GITHUB_APP_ID=${GITHUB_APP_ID}
@@ -387,7 +387,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      dragonfly:
+      valkey:
         condition: service_healthy
 
   web:
@@ -420,26 +420,23 @@ services:
       timeout: 5s
       retries: 5
 
-  dragonfly:
-    image: docker.dragonflydb.io/dragonflydb/dragonfly
-    container_name: sweetr-dragonfly
-    command: ["--cluster_mode=emulated", "--lock_on_hashtags", "--proactor_threads=2"]
-    ulimits:
-      memlock: -1
+  valkey:
+    image: valkey/valkey:8-alpine
+    container_name: sweetr-valkey
     volumes:
-      - sweetr-dragonfly:/data
+      - sweetr-valkey:/data
     restart: unless-stopped
     networks:
       - sweetr
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping"]
+      test: ["CMD-SHELL", "valkey-cli ping"]
       interval: 10s
       timeout: 5s
       retries: 5
 
 volumes:
   sweetr-db:
-  sweetr-dragonfly:
+  sweetr-valkey:
   sweetr-caddy-data:
   sweetr-caddy-config:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - app_network
     depends_on:
       - postgres
-      - dragonfly
+      - valkey
   web:
     container_name: sweetr-web
     build:
@@ -62,22 +62,23 @@ services:
       - "5433:5432"
     volumes:
       - ./apps/api/init-app-db.sh:/docker-entrypoint-initdb.d/init-app-db.sh
-  dragonfly:
-    image: "docker.dragonflydb.io/dragonflydb/dragonfly"
-    ulimits:
-      memlock: -1
-    command:
-      ["--cluster_mode=emulated", "--lock_on_hashtags", "--proactor_threads=4"]
+  valkey:
+    image: "valkey/valkey:8-alpine"
     ports:
       - "6379:6379"
     volumes:
-      - dragonflydata:/data
+      - valkeydata:/data
     networks:
       - app_network
+    healthcheck:
+      test: ["CMD-SHELL", "valkey-cli ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   docker-sweetr-db:
-  dragonflydata:
+  valkeydata:
 networks:
   app_network:
     driver: bridge


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sweetr-dev/sweetr.dev/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces Dragonfly with Valkey across CI, local Compose, generated self-hosting configuration, and documentation.
- Updates service names, connection strings, images, health checks, and volumes for Valkey.
- Adds a Valkey health check to the root development Compose stack.
- The generated deployment does not migrate Redis-backed state or retire the renamed Dragonfly service during upgrades.

<h3>Confidence Score: 4/5</h3>

The upgrade path should be fixed before merging because existing self-hosted installations can lose persisted queue and application state when the deployment switches to the new Valkey volume.

The generated deployment replaces the mounted Dragonfly volume without transferring Redis-backed queues and state, while also leaving the renamed Dragonfly container running as an orphan.

**Files Needing Attention:** bin/deploy and apps/docs/get-started/self-host.mdx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| bin/deploy | Generates the Valkey deployment but neither migrates the prior Redis-backed volume nor removes the renamed Dragonfly service during upgrades. |
| docker-compose.yml | Replaces the local Dragonfly service and volume with a health-checked Valkey service; existing local state moves to a newly named volume. |
| apps/docs/get-started/self-host.mdx | Updates self-hosting examples for Valkey but retains an upgrade command that does not clean up the old service or address state migration. |
| .github/workflows/docker-publish.yml | Replaces the workflow's Dragonfly service with a health-checked Valkey 8 service. |
| .github/workflows/test-integration.yml | Runs integration tests against Valkey 8 using its native CLI health check. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Existing self-hosted stack] --> B[Dragonfly container]
  B --> C[(sweetr-dragonfly volume)]
  A --> D[Re-run deployment]
  D --> E[Generated Compose uses Valkey]
  E --> F[(new sweetr-valkey volume)]
  E --> G[Valkey starts with empty state]
  C -. no migration .-> F
  B --> H[Orphaned running container]
```

<sub>Reviews (1): Last reviewed commit: ["feat: valkey"](https://github.com/sweetr-dev/sweetr.dev/commit/4ba05ec6fd782ff904af251659d98d8020d393fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51546473)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->